### PR TITLE
feat: DebugHandler

### DIFF
--- a/EduardoKirkCommand/DebugHandler.swift
+++ b/EduardoKirkCommand/DebugHandler.swift
@@ -1,0 +1,22 @@
+//
+//  DebugHandler.swift
+//  EduardoKirk
+//
+//  Created by ohataken on 2025/12/21.
+//
+
+import Foundation
+
+struct DebugHandler: CommandHandlerProtocol {
+    static func doesCommandMatch(_ args: [String]) -> Bool {
+        return args.count > 1 && args[1] == "debug"
+    }
+
+    static func handle(args: [String], stdin: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = ["-e", "display notification \"DebugHandler\" with title \"DebugHandler\" sound name \"Glass\""]
+        try? process.run()
+        process.waitUntilExit()
+    }
+}

--- a/EduardoKirkCommand/main.swift
+++ b/EduardoKirkCommand/main.swift
@@ -21,6 +21,8 @@ if SessionStartHandler.doesCommandMatch(args) {
     StopHandler.handle(args: args, stdin: stdin)
 } else if UserPromptSubmitHandler.doesCommandMatch(args) {
     UserPromptSubmitHandler.handle(args: args, stdin: stdin)
+} else if DebugHandler.doesCommandMatch(args) {
+    DebugHandler.handle(args: args, stdin: stdin)
 } else {
     print("Unknown command")
 }


### PR DESCRIPTION
debug 用のコマンドを追加

# 背景

transcript file 中のダブルクオートやバッククオートが osascript のほうでパースエラーになってしまう問題がある。エスケープの処理の振る舞いを調査するために追加した。