### PR TITLE
chore: TranscriptMessageContentInputPayload から new_string と old_string を取り除いた

### DIFF
--- a/EduardoKirkCommand/TranscriptMessageContentInputPayload.swift
+++ b/EduardoKirkCommand/TranscriptMessageContentInputPayload.swift
@@ -9,6 +9,4 @@ struct TranscriptMessageContentInputPayload: Codable {
     let description: String?
     let plan: String?
     let file_path: String?
-    let new_string: String?
-    let old_string: String?
 }


### PR DESCRIPTION
### new_string と old_string

- #64 で追加した
- transcript file の中の message, content, input のプロパティ
- Claude Code が提案する差分をあらわす

### なぜ取り除くか

- 通知に使わなくなったため
  - new_string, old_string の文字列が長すぎて通知に適さないため
  - 代わりに file_path にした #68
