### PR TITLE
refactor: TranscriptPayload の timestamp を Date? 型にした

### DIFF
--- a/EduardoKirkCommand/NotificationHandler.swift
+++ b/EduardoKirkCommand/NotificationHandler.swift
@@ -21,6 +21,7 @@ struct NotificationHandler: CommandHandlerProtocol {
         }
 
         let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
         guard let payload = try? decoder.decode(NotificationHookPayload.self, from: data) else {
             print("Failed to decode NotificationHookPayload")
             return

--- a/EduardoKirkCommand/StopHandler.swift
+++ b/EduardoKirkCommand/StopHandler.swift
@@ -21,6 +21,7 @@ struct StopHandler: CommandHandlerProtocol {
         }
 
         let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
         guard let payload = try? decoder.decode(StopHookPayload.self, from: data) else {
             print("Failed to decode StopHookPayload")
             return

--- a/EduardoKirkCommand/TranscriptFileParser.swift
+++ b/EduardoKirkCommand/TranscriptFileParser.swift
@@ -11,7 +11,7 @@ struct TranscriptFileParser {
             .filter { $0.timestamp != nil }
             .filter { $0.type == "assistant" }
             .max { a, b in
-                (a.timestamp ?? "") < (b.timestamp ?? "")
+                a.timestamp! < b.timestamp!
             }
     }
 

--- a/EduardoKirkCommand/TranscriptPayload.swift
+++ b/EduardoKirkCommand/TranscriptPayload.swift
@@ -5,12 +5,14 @@
 //  Created by ohataken on 2025/12/17.
 //
 
+import Foundation
+
 struct TranscriptPayload: Codable {
     let type: String
     let uuid: String?
     let sessionId: String?
     let userType: String?
     let cwd: String?
-    let timestamp: String?
+    let timestamp: Date?
     let message: TranscriptMessagePayload?
 }


### PR DESCRIPTION
# JSONDecoder と Date パースについてのメモ

## 問題の原因
- `timestamp` を `String?` → `Date?` に変更したが、JSONDecoder のデフォルト設定では ISO 8601 形式の文字列をパースできない
- デフォルト設定（`.deferredToDate`）は UNIX タイムスタンプ（数値）を期待している
- 結果として `timestamp` が常に `nil` になり、フィルター後に全レコードが除外されていた

## JSONDecoder で dateDecodingStrategy を設定する方法

**方法1: JSONDecoder インスタンスで設定（使う側）**
```swift
let decoder = JSONDecoder()
decoder.dateDecodingStrategy = .iso8601
let data = try decoder.decode(TranscriptPayload.self, from: jsonData)
```

**方法2: Codable 側でカスタムデコーダーを実装（推奨）**
- `init(from decoder: Decoder)` を実装
- ISO8601DateFormatter を使用して String から Date に変換
- 利点：Codable 構造体が自身の仕様を管理し、使用側で strategy 設定の手間がない

## ISO 8601 形式
- 例: `2025-12-25T19:00:00.000Z`
- 標準フォーマットであり、`ISO8601DateFormatter` で自動パースできる

## 結論
`timestamp: Date?` を使いたい場合は、`TranscriptPayload` にカスタムデコーダーを書くほうがスケーラビリティが高い
