### PR TITLE
feat: add notification_type to NotificationHookPayload

### DIFF
--- a/EduardoKirkCommand/NotificationHookPayload.swift
+++ b/EduardoKirkCommand/NotificationHookPayload.swift
@@ -12,6 +12,7 @@ struct NotificationHookPayload: Codable {
     let transcriptPath: String
     let cwd: String
     let hookEventName: String
+    let notificationType: String?
     let timestamp: Date?
 
     enum CodingKeys: String, CodingKey {
@@ -19,6 +20,7 @@ struct NotificationHookPayload: Codable {
         case transcriptPath = "transcript_path"
         case cwd
         case hookEventName = "hook_event_name"
+        case notificationType = "notification_type"
         case timestamp
     }
 


### PR DESCRIPTION
## Summary
- Add `notification_type` decoding support to `NotificationHookPayload`

## Test
- Not run in this PR; payload field addition only