### PR TITLE
feat: skip idol_prompt notifications

### DIFF
--- a/EduardoKirkCommand/NotificationHandler.swift
+++ b/EduardoKirkCommand/NotificationHandler.swift
@@ -27,6 +27,10 @@ struct NotificationHandler: CommandHandlerProtocol {
             return
         }
 
+        guard payload.notificationType != "idol_prompt" else {
+            return
+        }
+
         guard let fileContent = try? String(contentsOfFile: payload.transcriptPath, encoding: .utf8) else {
             fputs("Failed to read transcript file", stderr)
             return

--- a/spec/notification/notification_spec.rb
+++ b/spec/notification/notification_spec.rb
@@ -16,5 +16,20 @@ RSpec.describe "EduardoKirk notification" do
       expect(stdout).to be_empty
       expect(stderr).to be_empty
     end
+
+    it "skips idol_prompt notifications" do
+      stdin_data = {
+        session_id: "00000000-0000-0000-0000-000000000000",
+        transcript_path: Pathname.new(__dir__).join("./missing_transcript_file.jsonl").to_s,
+        cwd: Pathname.getwd.to_s,
+        hook_event_name: "Notification",
+        message: "hello world",
+        notification_type: "idol_prompt"
+      }
+
+      stdout, stderr, status = Open3.capture3(ENV["EDUARDO_KIRK_PATH"], "notification", stdin_data: stdin_data.to_json)
+      expect(stdout).to be_empty
+      expect(stderr).to be_empty
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Skip notification handling when `notification_type` is `idol_prompt`
- Add a notification spec covering the early return path

## Test
- `swiftc EduardoKirkCommand/*.swift -o /private/tmp/eduardo-kirk`
- `EDUARDO_KIRK_PATH=/private/tmp/eduardo-kirk bundle exec rspec spec/notification/notification_spec.rb:20`