### PR TITLE
chore: bump version to 0.1.16

### DIFF
--- a/EduardoKirk.xcodeproj/project.pbxproj
+++ b/EduardoKirk.xcodeproj/project.pbxproj
@@ -489,7 +489,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 0.1.15;
+				MARKETING_VERSION = 0.1.16;
 				PRODUCT_BUNDLE_IDENTIFIER = io.github.ohataken.EduardoKirk;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -520,7 +520,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 0.1.15;
+				MARKETING_VERSION = 0.1.16;
 				PRODUCT_BUNDLE_IDENTIFIER = io.github.ohataken.EduardoKirk;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
## Summary
- Bump Swift project `MARKETING_VERSION` to `0.1.16`
- Leave Homebrew Formula version/SHA unchanged for the later release asset update

## Test
- Not run; project version metadata only