### PR TITLE
chore: update Formula for 0.1.16

### DIFF
--- a/Formula/eduardo-kirk.rb
+++ b/Formula/eduardo-kirk.rb
@@ -1,9 +1,9 @@
 class EduardoKirk < Formula
   desc "desktop notifications for Claude Code"
   homepage "https://github.com/ohataken/eduardo-kirk"
-  version "0.1.15"
+  version "0.1.16"
   url "https://github.com/ohataken/eduardo-kirk/releases/download/v#{version}/eduardo-kirk-#{version}.tar.gz"
-  sha256 "5105178672cf3259ba4157c4549dda2daee0bd725498b1174f251b3fd18894b4"
+  sha256 "5e668c5b3ceb04f8451fce977d9b37d3adaa4902fa42ab674ffcf4081c2eb002"
   
   def install
     bin.install "EduardoKirkCommand" => "eduardo-kirk"


### PR DESCRIPTION
## Summary
- Update Homebrew Formula version to `0.1.16`
- Update Formula SHA256 for `eduardo-kirk-0.1.16.tar.gz`

## Release asset
- Draft release: `v0.1.16`
- Asset: `eduardo-kirk-0.1.16.tar.gz`
- SHA256: `5e668c5b3ceb04f8451fce977d9b37d3adaa4902fa42ab674ffcf4081c2eb002`

## Test
- `shasum -a 256 /private/tmp/eduardo-kirk-release-0.1.16/eduardo-kirk-0.1.16.tar.gz`