### PR TITLE
feat: add notification type to stop payload

### DIFF
--- a/EduardoKirkCommand/StopHookPayload.swift
+++ b/EduardoKirkCommand/StopHookPayload.swift
@@ -13,6 +13,7 @@ struct StopHookPayload: Codable {
     let cwd: String
     let hookEventName: String
     let stopHookActive: Bool
+    let notificationType: String?
 
     enum CodingKeys: String, CodingKey {
         case sessionId = "session_id"
@@ -20,6 +21,7 @@ struct StopHookPayload: Codable {
         case cwd
         case hookEventName = "hook_event_name"
         case stopHookActive = "stop_hook_active"
+        case notificationType = "notification_type"
     }
 
     var cwdURL: URL {


### PR DESCRIPTION
## Summary
- Add `notification_type` decoding to `StopHookPayload`
- Keep the field optional so existing Stop hook payloads continue to decode

## Test
- Not run locally; build/checks will run in GitHub Actions.