### PR TITLE
feat: skip idol_prompt stop notifications

### DIFF
--- a/EduardoKirkCommand/StopHandler.swift
+++ b/EduardoKirkCommand/StopHandler.swift
@@ -27,6 +27,10 @@ struct StopHandler: CommandHandlerProtocol {
             return
         }
 
+        guard payload.notificationType != "idol_prompt" else {
+            return
+        }
+
         guard let fileContent = try? String(contentsOfFile: payload.transcriptPath, encoding: .utf8) else {
             fputs("Failed to read transcript file", stderr)
             return

--- a/spec/stop/stop_spec.rb
+++ b/spec/stop/stop_spec.rb
@@ -15,5 +15,20 @@ RSpec.describe "EduardoKirk stop" do
       expect(stdout).to be_empty
       expect(stderr).to be_empty
     end
+
+    it "skips idol_prompt stops" do
+      stdin_data = {
+        session_id: "00000000-0000-0000-0000-000000000000",
+        transcript_path: Pathname.new(__dir__).join("./missing_transcript_file.jsonl").to_s,
+        cwd: Pathname.getwd.to_s,
+        hook_event_name: "Stop",
+        stop_hook_active: false,
+        notification_type: "idol_prompt"
+      }
+
+      stdout, stderr, status = Open3.capture3(ENV["EDUARDO_KIRK_PATH"], "stop", stdin_data: stdin_data.to_json)
+      expect(stdout).to be_empty
+      expect(stderr).to be_empty
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Skip Stop notification handling when `notification_type` is `idol_prompt`
- Add a Stop spec covering the early return path before transcript file reads

## Test
- Not run locally; build/checks will run in GitHub Actions.