### PR TITLE
chore: bump version to 0.1.17

### DIFF
--- a/EduardoKirk.xcodeproj/project.pbxproj
+++ b/EduardoKirk.xcodeproj/project.pbxproj
@@ -489,7 +489,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 0.1.16;
+				MARKETING_VERSION = 0.1.17;
 				PRODUCT_BUNDLE_IDENTIFIER = io.github.ohataken.EduardoKirk;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -520,7 +520,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 0.1.16;
+				MARKETING_VERSION = 0.1.17;
 				PRODUCT_BUNDLE_IDENTIFIER = io.github.ohataken.EduardoKirk;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
## Summary
- Bump `MARKETING_VERSION` from `0.1.16` to `0.1.17`

## Test
- Not run locally; release build will run via GitHub Actions.