### PR TITLE
chore: update Formula for 0.1.17

### DIFF
--- a/Formula/eduardo-kirk.rb
+++ b/Formula/eduardo-kirk.rb
@@ -1,9 +1,9 @@
 class EduardoKirk < Formula
   desc "desktop notifications for Claude Code"
   homepage "https://github.com/ohataken/eduardo-kirk"
-  version "0.1.16"
+  version "0.1.17"
   url "https://github.com/ohataken/eduardo-kirk/releases/download/v#{version}/eduardo-kirk-#{version}.tar.gz"
-  sha256 "5e668c5b3ceb04f8451fce977d9b37d3adaa4902fa42ab674ffcf4081c2eb002"
+  sha256 "f08d0249bb382ac0a08a4411cb00fbd18aabd188a62a02581169f28102dfaa38"
   
   def install
     bin.install "EduardoKirkCommand" => "eduardo-kirk"


### PR DESCRIPTION
## Summary
- Update Homebrew Formula version to `0.1.17`
- Update SHA256 for `eduardo-kirk-0.1.17.tar.gz`

## Test
- Release asset SHA256 calculated with `shasum -a 256 /private/tmp/eduardo-kirk-0.1.17.tar.gz`