### PR TITLE
fix: remove session start notification sound

### DIFF
--- a/EduardoKirkCommand/SessionStartHandler.swift
+++ b/EduardoKirkCommand/SessionStartHandler.swift
@@ -28,8 +28,7 @@ struct SessionStartHandler: CommandHandlerProtocol {
 
         try? notifier.notify(
             message: payload.cwd,
-            title: "SessionStart - \(payload.cwdURL.lastPathComponent)",
-            soundName: "Glass"
+            title: "SessionStart - \(payload.cwdURL.lastPathComponent)"
         )
     }
 }


### PR DESCRIPTION
## Summary

Remove the explicit `Glass` sound from the SessionStart desktop notification.

## Why

SessionStart notifications do not need an audible sound. Omitting `soundName` lets the notifier send the notification without a sound name.

## Validation

- `swiftc EduardoKirkCommand/*.swift` passed in `/private/tmp/eduardo-kirk-session-start`
- `xcodebuild` was not available because the active developer directory is CommandLineTools
- `bundle exec rspec` was not available because bundler 2.6.9 is not installed