### PR TITLE
fix: remove session end notification sound

### DIFF
--- a/EduardoKirkCommand/SessionEndHandler.swift
+++ b/EduardoKirkCommand/SessionEndHandler.swift
@@ -28,8 +28,7 @@ struct SessionEndHandler: CommandHandlerProtocol {
 
         try? notifier.notify(
             message: payload.cwd,
-            title: "SessionEnd - \(payload.cwdURL.lastPathComponent)",
-            soundName: "Glass"
+            title: "SessionEnd - \(payload.cwdURL.lastPathComponent)"
         )
     }
 }


### PR DESCRIPTION
## Summary

Remove the explicit `Glass` sound from the SessionEnd desktop notification.

## Why

SessionEnd notifications do not need an audible sound. Omitting `soundName` lets the notifier send the notification without a sound name.

## Validation

- `swiftc EduardoKirkCommand/*.swift` passed in `/private/tmp/eduardo-kirk-session-end`
- `xcodebuild` was not available because the active developer directory is CommandLineTools
- `bundle exec rspec` was not available because bundler 2.6.9 is not installed