### PR TITLE
fix: remove user prompt submit notification sound

### DIFF
--- a/EduardoKirkCommand/UserPromptSubmitHandler.swift
+++ b/EduardoKirkCommand/UserPromptSubmitHandler.swift
@@ -28,8 +28,7 @@ struct UserPromptSubmitHandler: CommandHandlerProtocol {
 
         try? notifier.notify(
             message: payload.prompt,
-            title: "UserPromptSubmit - \(payload.cwdURL.lastPathComponent)",
-            soundName: "Glass"
+            title: "UserPromptSubmit - \(payload.cwdURL.lastPathComponent)"
         )
     }
 }


### PR DESCRIPTION
## Summary

Remove the explicit `Glass` sound from the UserPromptSubmit desktop notification.

## Why

UserPromptSubmit notifications do not need an audible sound. Omitting `soundName` lets the notifier send the notification without a sound name.

## Validation

- `swiftc EduardoKirkCommand/*.swift` passed in `/private/tmp/eduardo-kirk-user-prompt-submit`
- `xcodebuild` was not available because the active developer directory is CommandLineTools
- `bundle exec rspec` was not available because bundler 2.6.9 is not installed