### PR TITLE
fix: use content sound for stop notifications

### DIFF
--- a/EduardoKirkCommand/StopHandler.swift
+++ b/EduardoKirkCommand/StopHandler.swift
@@ -53,7 +53,7 @@ struct StopHandler: CommandHandlerProtocol {
         try? notifier.notify(
             message: message,
             title: "Stop (\(content.type)) - \(payload.cwdURL.lastPathComponent)",
-            soundName: "Glass"
+            soundName: content.soundName
         )
     }
 }


### PR DESCRIPTION
## Summary

Update Stop notifications to use the same content-based sound selection as Notification notifications.

## Why

Stop already reads the latest assistant transcript content and includes `content.type` in the title. Using `content.soundName` makes its audible behavior match Notification for `tool_use`, `thinking`, `tool_result`, `text`, and unknown content types.

## Validation

- `swiftc EduardoKirkCommand/*.swift` passed in `/private/tmp/eduardo-kirk-stop-content-sound`