### PR TITLE
chore: bump version to 0.1.18

### DIFF
--- a/EduardoKirk.xcodeproj/project.pbxproj
+++ b/EduardoKirk.xcodeproj/project.pbxproj
@@ -489,7 +489,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 0.1.17;
+				MARKETING_VERSION = 0.1.18;
 				PRODUCT_BUNDLE_IDENTIFIER = io.github.ohataken.EduardoKirk;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -520,7 +520,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 0.1.17;
+				MARKETING_VERSION = 0.1.18;
 				PRODUCT_BUNDLE_IDENTIFIER = io.github.ohataken.EduardoKirk;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
## Summary

Bump the EduardoKirk marketing version from `0.1.17` to `0.1.18`.

## Why

This prepares the project for the v0.1.18 release.

## Validation

- Confirmed `MARKETING_VERSION` is `0.1.18` for the EduardoKirk Debug and Release build configurations
- No build was run; this is a project version metadata-only change