### PR TITLE
chore: update Formula for 0.1.18

### DIFF
--- a/Formula/eduardo-kirk.rb
+++ b/Formula/eduardo-kirk.rb
@@ -1,9 +1,9 @@
 class EduardoKirk < Formula
   desc "desktop notifications for Claude Code"
   homepage "https://github.com/ohataken/eduardo-kirk"
-  version "0.1.17"
+  version "0.1.18"
   url "https://github.com/ohataken/eduardo-kirk/releases/download/v#{version}/eduardo-kirk-#{version}.tar.gz"
-  sha256 "f08d0249bb382ac0a08a4411cb00fbd18aabd188a62a02581169f28102dfaa38"
+  sha256 "92c106fe96682ebe7e660020ef40a57a7744fded9ce5d5d99872d4ecb484298d"
   
   def install
     bin.install "EduardoKirkCommand" => "eduardo-kirk"


### PR DESCRIPTION
## Summary

Update the Homebrew formula for v0.1.18.

## Changes

- Bump `version` from `0.1.17` to `0.1.18`
- Update `sha256` for `eduardo-kirk-0.1.18.tar.gz`

## Validation

- Confirmed the v0.1.18 release asset exists at `https://github.com/ohataken/eduardo-kirk/releases/download/v0.1.18/eduardo-kirk-0.1.18.tar.gz`
- `ruby -c Formula/eduardo-kirk.rb`