### PR TITLE
chore: update workflow actions for node24

### DIFF
--- a/.github/workflows/build-eduardo-kirk-command.yml
+++ b/.github/workflows/build-eduardo-kirk-command.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         ref: ${{ github.event.inputs.branch }}
 
@@ -38,7 +38,7 @@ jobs:
         shasum -a 256 eduardo-kirk-x.x.x.tar.gz
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: eduardo-kirk-build
         path: eduardo-kirk-x.x.x.tar.gz


### PR DESCRIPTION
## Summary

Update the build workflow actions to versions that run on Node.js 24.

## Changes

- `actions/checkout@v4` -> `actions/checkout@v7`
- `actions/upload-artifact@v4` -> `actions/upload-artifact@v7`

## Why

GitHub Actions reports that Node.js 20 is deprecated and these older action versions are being forced to run on Node.js 24. Updating the actions removes that deprecation path from the workflow.

## Validation

- Confirmed `actions/checkout@v7` uses `node24`
- Confirmed `actions/upload-artifact@v7` uses `node24`
- Parsed `.github/workflows/build-eduardo-kirk-command.yml` as YAML successfully