### PR TITLE
fix: skip idle prompt notifications

### DIFF
--- a/EduardoKirkCommand/NotificationHandler.swift
+++ b/EduardoKirkCommand/NotificationHandler.swift
@@ -27,7 +27,7 @@ struct NotificationHandler: CommandHandlerProtocol {
             return
         }
 
-        guard payload.notificationType != "idol_prompt" else {
+        guard payload.notificationType != "idle_prompt" else {
             return
         }
 

--- a/EduardoKirkCommand/StopHandler.swift
+++ b/EduardoKirkCommand/StopHandler.swift
@@ -27,7 +27,7 @@ struct StopHandler: CommandHandlerProtocol {
             return
         }
 
-        guard payload.notificationType != "idol_prompt" else {
+        guard payload.notificationType != "idle_prompt" else {
             return
         }
 


### PR DESCRIPTION
## Summary

- Fix the notification type guard typo from `idol_prompt` to `idle_prompt`
- Apply the same guard correction to both `Notification` and `Stop` handlers

## Why

Claude sends idle wait notifications with `notification_type: "idle_prompt"`. The current implementation checks `"idol_prompt"`, so idle prompt notifications are not skipped.

## Validation

- Not run per request; spec updates/verification will be handled separately.