### PR TITLE
chore: update Formula for 0.1.19

### DIFF
--- a/Formula/eduardo-kirk.rb
+++ b/Formula/eduardo-kirk.rb
@@ -1,9 +1,9 @@
 class EduardoKirk < Formula
   desc "desktop notifications for Claude Code"
   homepage "https://github.com/ohataken/eduardo-kirk"
-  version "0.1.18"
+  version "0.1.19"
   url "https://github.com/ohataken/eduardo-kirk/releases/download/v#{version}/eduardo-kirk-#{version}.tar.gz"
-  sha256 "92c106fe96682ebe7e660020ef40a57a7744fded9ce5d5d99872d4ecb484298d"
+  sha256 "4cde68a1ef964e1495e449fa9fff55bf540c95fe232efe0d4e694972127721df"
   
   def install
     bin.install "EduardoKirkCommand" => "eduardo-kirk"


### PR DESCRIPTION
## Summary

- Update Homebrew formula version from `0.1.18` to `0.1.19`
- Update sha256 to match the `v0.1.19` release asset

## Release Asset

- Release: https://github.com/ohataken/eduardo-kirk/releases/tag/v0.1.19
- Asset: `eduardo-kirk-0.1.19.tar.gz`
- sha256: `4cde68a1ef964e1495e449fa9fff55bf540c95fe232efe0d4e694972127721df`

## Validation

- Verified GitHub release asset digest via API
- Local sha256 of downloaded artifact matches the formula value