### PR TITLE
Add command to transcript input payload

### DIFF
--- a/EduardoKirkCommand/TranscriptMessageContentInputPayload.swift
+++ b/EduardoKirkCommand/TranscriptMessageContentInputPayload.swift
@@ -7,4 +7,5 @@
 
 struct TranscriptMessageContentInputPayload: Codable {
     let description: String?
+    let command: String?
 }


### PR DESCRIPTION
## Summary

- Add `command` to `TranscriptMessageContentInputPayload`.

## Context

This prepares the transcript input payload model for tool-specific notification message formatting.

## Validation

- `swiftc -module-cache-path /private/tmp/swift-module-cache-builder-only EduardoKirkCommand/*.swift -o /private/tmp/eduardo-kirk-builder-only-check` passed on the full local stack.