### PR TITLE
Add filePath to transcript input payload

### DIFF
--- a/EduardoKirkCommand/TranscriptMessageContentInputPayload.swift
+++ b/EduardoKirkCommand/TranscriptMessageContentInputPayload.swift
@@ -8,4 +8,11 @@
 struct TranscriptMessageContentInputPayload: Codable {
     let description: String?
     let command: String?
+    let filePath: String?
+
+    enum CodingKeys: String, CodingKey {
+        case description
+        case command
+        case filePath = "file_path"
+    }
 }


### PR DESCRIPTION
## Summary

- Add `filePath` to `TranscriptMessageContentInputPayload`.
- Decode it from the transcript `file_path` key.

## Context

This prepares the transcript input payload model for file-related tool notification messages.

## Validation

- `swiftc -module-cache-path /private/tmp/swift-module-cache-builder-only EduardoKirkCommand/*.swift -o /private/tmp/eduardo-kirk-builder-only-check` passed on the full local stack.