### PR TITLE
Add content to transcript input payload

### DIFF
--- a/EduardoKirkCommand/TranscriptMessageContentInputPayload.swift
+++ b/EduardoKirkCommand/TranscriptMessageContentInputPayload.swift
@@ -9,10 +9,12 @@ struct TranscriptMessageContentInputPayload: Codable {
     let description: String?
     let command: String?
     let filePath: String?
+    let content: String?
 
     enum CodingKeys: String, CodingKey {
         case description
         case command
         case filePath = "file_path"
+        case content
     }
 }


### PR DESCRIPTION
## Summary

- Add `content` to `TranscriptMessageContentInputPayload`.

## Context

This prepares the transcript input payload model for transcript inputs that include inline content.

## Validation

- `swiftc -module-cache-path /private/tmp/swift-module-cache-builder-only EduardoKirkCommand/*.swift -o /private/tmp/eduardo-kirk-builder-only-check` passed on the full local stack.