### PR TITLE
Add offset to transcript input payload

### DIFF
--- a/EduardoKirkCommand/TranscriptMessageContentInputPayload.swift
+++ b/EduardoKirkCommand/TranscriptMessageContentInputPayload.swift
@@ -10,11 +10,13 @@ struct TranscriptMessageContentInputPayload: Codable {
     let command: String?
     let filePath: String?
     let content: String?
+    let offset: Int?
 
     enum CodingKeys: String, CodingKey {
         case description
         case command
         case filePath = "file_path"
         case content
+        case offset
     }
 }


### PR DESCRIPTION
## Summary

- Add `offset` to `TranscriptMessageContentInputPayload`.

## Context

This prepares the transcript input payload model for transcript inputs that include a read offset.

## Validation

- `swiftc -module-cache-path /private/tmp/swift-module-cache-builder-only EduardoKirkCommand/*.swift -o /private/tmp/eduardo-kirk-builder-only-check` passed on the full local stack.