### PR TITLE
Add limit to transcript input payload

### DIFF
--- a/EduardoKirkCommand/TranscriptMessageContentInputPayload.swift
+++ b/EduardoKirkCommand/TranscriptMessageContentInputPayload.swift
@@ -11,6 +11,7 @@ struct TranscriptMessageContentInputPayload: Codable {
     let filePath: String?
     let content: String?
     let offset: Int?
+    let limit: Int?
 
     enum CodingKeys: String, CodingKey {
         case description
@@ -18,5 +19,6 @@ struct TranscriptMessageContentInputPayload: Codable {
         case filePath = "file_path"
         case content
         case offset
+        case limit
     }
 }


### PR DESCRIPTION
## Summary

- Add `limit` to `TranscriptMessageContentInputPayload`.

## Context

This prepares the transcript input payload model for transcript inputs that include a read limit.

## Validation

- `swiftc -module-cache-path /private/tmp/swift-module-cache-builder-only EduardoKirkCommand/*.swift -o /private/tmp/eduardo-kirk-builder-only-check` passed on the full local stack.