### PR TITLE
Add replaceAll to transcript input payload

### DIFF
--- a/EduardoKirkCommand/TranscriptMessageContentInputPayload.swift
+++ b/EduardoKirkCommand/TranscriptMessageContentInputPayload.swift
@@ -12,6 +12,7 @@ struct TranscriptMessageContentInputPayload: Codable {
     let content: String?
     let offset: Int?
     let limit: Int?
+    let replaceAll: Bool?
 
     enum CodingKeys: String, CodingKey {
         case description
@@ -20,5 +21,6 @@ struct TranscriptMessageContentInputPayload: Codable {
         case content
         case offset
         case limit
+        case replaceAll = "replace_all"
     }
 }


### PR DESCRIPTION
## Summary

- Add `replaceAll` to `TranscriptMessageContentInputPayload`.
- Decode it from the transcript `replace_all` key.

## Context

This prepares the transcript input payload model for edit-related tool notification messages.

## Validation

- `swiftc -module-cache-path /private/tmp/swift-module-cache-builder-only EduardoKirkCommand/*.swift -o /private/tmp/eduardo-kirk-builder-only-check` passed on the full local stack.