### PR TITLE
Fix idle prompt notification type specs

### DIFF
--- a/spec/notification/notification_spec.rb
+++ b/spec/notification/notification_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe "EduardoKirk notification" do
       expect(stderr).to be_empty
     end
 
-    it "skips idol_prompt notifications" do
+    it "skips idle_prompt notifications" do
       stdin_data = {
         session_id: "00000000-0000-0000-0000-000000000000",
         transcript_path: Pathname.new(__dir__).join("./missing_transcript_file.jsonl").to_s,
         cwd: Pathname.getwd.to_s,
         hook_event_name: "Notification",
         message: "hello world",
-        notification_type: "idol_prompt"
+        notification_type: "idle_prompt"
       }
 
       stdout, stderr, status = Open3.capture3(ENV["EDUARDO_KIRK_PATH"], "notification", stdin_data: stdin_data.to_json)

--- a/spec/stop/stop_spec.rb
+++ b/spec/stop/stop_spec.rb
@@ -16,14 +16,14 @@ RSpec.describe "EduardoKirk stop" do
       expect(stderr).to be_empty
     end
 
-    it "skips idol_prompt stops" do
+    it "skips idle_prompt stops" do
       stdin_data = {
         session_id: "00000000-0000-0000-0000-000000000000",
         transcript_path: Pathname.new(__dir__).join("./missing_transcript_file.jsonl").to_s,
         cwd: Pathname.getwd.to_s,
         hook_event_name: "Stop",
         stop_hook_active: false,
-        notification_type: "idol_prompt"
+        notification_type: "idle_prompt"
       }
 
       stdout, stderr, status = Open3.capture3(ENV["EDUARDO_KIRK_PATH"], "stop", stdin_data: stdin_data.to_json)


### PR DESCRIPTION
## Summary

- Fix notification and stop specs to use `idle_prompt` instead of the typo `idol_prompt`.
- Keep the test descriptions aligned with the implemented hook notification type.

## Context

The implementation skips `idle_prompt` notifications, but these two specs still used the old typo. That meant they did not cover the skip path and attempted to read the intentionally missing transcript file.

## Validation

- `env EDUARDO_KIRK_PATH=/private/tmp/eduardo-kirk-review /Users/ken.ohata/.local/share/mise/shims/bundle exec rspec spec/notification/notification_spec.rb:20 spec/stop/stop_spec.rb:19` passed.