### PR TITLE
fix: prefer input description for Read/Write/Edit notification messages

### DIFF
--- a/EduardoKirkCommand/TranscriptNotificationMessageBuilder.swift
+++ b/EduardoKirkCommand/TranscriptNotificationMessageBuilder.swift
@@ -28,11 +28,11 @@ struct TranscriptNotificationMessageBuilder {
         case "Bash":
             return input.description ?? input.command.map { "Bash: \($0)" } ?? content.name
         case "Read":
-            return fileMessage(prefix: "Read", input: input)
+            return input.description ?? fileMessage(prefix: "Read", input: input)
         case "Write":
-            return writeMessage(input: input)
+            return input.description ?? writeMessage(input: input)
         case "Edit":
-            return editMessage(input: input)
+            return input.description ?? editMessage(input: input)
         default:
             return input.description ?? content.name
         }


### PR DESCRIPTION
## Summary

- For `Read` / `Write` / `Edit` `tool_use` messages, prefer `input.description` when present and fall back to the tool-specific structured message only when it is `nil`.
- Brings these branches in line with `Bash` and the `default` branch in `TranscriptNotificationMessageBuilder.buildToolMessage`.

## Context

In #173, the message builder was refactored to synthesize tool-specific strings (e.g. `Read <path> (offset X, limit Y)`) for `Read` / `Write` / `Edit`. That refactor unintentionally dropped the previous behavior of using `input.description` when the transcript already provided one, so any human-readable description Claude included was replaced with the mechanically-built string.

This restores the earlier precedence while keeping the structured fallback for the (common) case where `input.description` is absent.

## Validation

- `swiftc -module-cache-path /private/tmp/swift-module-cache-builder-only EduardoKirkCommand/*.swift -o /private/tmp/eduardo-kirk-builder-only-check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)