### PR TITLE
chore: swap Glass for Bottle as tool_use notification sound

### DIFF
--- a/EduardoKirkCommand/DebugHandler.swift
+++ b/EduardoKirkCommand/DebugHandler.swift
@@ -18,7 +18,7 @@ struct DebugHandler: CommandHandlerProtocol {
         try? notifier.notify(
             message: "DebugHandler",
             title: "DebugHandler",
-            soundName: "Glass"
+            soundName: "Bottle"
         )
     }
 }

--- a/EduardoKirkCommand/TranscriptMessageContentPayload.swift
+++ b/EduardoKirkCommand/TranscriptMessageContentPayload.swift
@@ -16,7 +16,7 @@ struct TranscriptMessageContentPayload: Codable {
     var soundName: String? {
         switch type {
         case "tool_use":
-            return "Glass"
+            return "Bottle"
         case "thinking":
             return "Tink"
         case "tool_result":


### PR DESCRIPTION
## Summary

- Replace the `Glass` sound with `Bottle` for `tool_use` notifications.
- Applies to `TranscriptMessageContentPayload.soundName` and `DebugHandler`.

## Context

Personal preference — `Bottle` reads more pleasantly than `Glass` as the per-tool notification cue. No other sound assignments (`Tink` for thinking, `Sosumi` for tool_result, `Morse` for text) are touched.

## Validation

- `swiftc -module-cache-path /private/tmp/swift-module-cache-builder-only EduardoKirkCommand/*.swift -o /private/tmp/eduardo-kirk-builder-only-check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)