### PR TITLE
chore: bump version to 0.1.20

### DIFF
--- a/EduardoKirk.xcodeproj/project.pbxproj
+++ b/EduardoKirk.xcodeproj/project.pbxproj
@@ -489,7 +489,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 0.1.19;
+				MARKETING_VERSION = 0.1.20;
 				PRODUCT_BUNDLE_IDENTIFIER = io.github.ohataken.EduardoKirk;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -520,7 +520,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 0.1.19;
+				MARKETING_VERSION = 0.1.20;
 				PRODUCT_BUNDLE_IDENTIFIER = io.github.ohataken.EduardoKirk;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
## Summary

- Bump `EduardoKirkCommand` marketing version from `0.1.19` to `0.1.20`

## Release Preparation

This follows the previous v0.1.19 release flow:

- version bump PR first
- tag/release from the merged bump commit as `v0.1.20`
- release body should point to `https://github.com/ohataken/eduardo-kirk/milestone/20?closed=1`
- upload asset as `eduardo-kirk-0.1.20.tar.gz`
- update `Formula/eduardo-kirk.rb` with version `0.1.20` and the release asset sha256 after the asset is available

## Validation

- Not run locally; this is a version metadata update only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)