### PR TITLE
chore: update Formula for 0.1.20

### DIFF
--- a/Formula/eduardo-kirk.rb
+++ b/Formula/eduardo-kirk.rb
@@ -1,9 +1,9 @@
 class EduardoKirk < Formula
   desc "desktop notifications for Claude Code"
   homepage "https://github.com/ohataken/eduardo-kirk"
-  version "0.1.19"
+  version "0.1.20"
   url "https://github.com/ohataken/eduardo-kirk/releases/download/v#{version}/eduardo-kirk-#{version}.tar.gz"
-  sha256 "4cde68a1ef964e1495e449fa9fff55bf540c95fe232efe0d4e694972127721df"
+  sha256 "27f94134d9e29283f2c144492e7e6e5102932c56c4052128672f6b36ca38971f"
   
   def install
     bin.install "EduardoKirkCommand" => "eduardo-kirk"


### PR DESCRIPTION
## Summary

- Update Homebrew formula version from `0.1.19` to `0.1.20`
- Update sha256 to match the `v0.1.20` release asset

## Release Asset

- Release: https://github.com/ohataken/eduardo-kirk/releases/tag/v0.1.20
- Asset: `eduardo-kirk-0.1.20.tar.gz`
- sha256: `27f94134d9e29283f2c144492e7e6e5102932c56c4052128672f6b36ca38971f`

## Validation

- Verified sha256 against the GitHub release asset digest returned by `gh release view v0.1.20`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)